### PR TITLE
Cache executable and also fixes the directory for self-hosted runner

### DIFF
--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -14,29 +14,25 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: install sver (linux and macos)
-      if: ${{ inputs.os == 'linux' || inputs.os == 'macos' }}
-      shell: bash
-      run: |
-        TEMPDIR=$(mktemp -d)
-        FILE_NAME="sver_${{ inputs.version }}_${{ inputs.os }}_amd64.zip"
-        FILE_URL="https://github.com/mitoma/sver/releases/download/${{ inputs.version }}/$FILE_NAME"
-        cd "$TEMPDIR"
-        curl -L "$FILE_URL" -o "$FILE_NAME"
-        unzip "$FILE_NAME"
-        mv sver /usr/local/bin
-        sver --help
+    - name: cache sver
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ runner.tool_cache }}/sver
+        key: ${{ runner.os }}-sver-${{ inputs.version }}-${{ inputs.os }}-amd64
 
-    - name: install sver (windows)
-      if: ${{ inputs.os == 'windows' }}
+    - name: install sver
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        mkdir -p "$HOME/bin"
-        TEMPDIR=$(mktemp -d)
         FILE_NAME="sver_${{ inputs.version }}_${{ inputs.os }}_amd64.zip"
         FILE_URL="https://github.com/mitoma/sver/releases/download/${{ inputs.version }}/$FILE_NAME"
-        cd "$TEMPDIR"
-        curl -L "$FILE_URL" -o "$FILE_NAME"
-        unzip "$FILE_NAME"
-        mv sver.exe "$HOME/bin"
-        sver --help
+        mkdir -p "${{ runner.tool_cache }}/sver"
+        cd "${{ runner.tool_cache }}/sver"
+        curl -f -L "$FILE_URL" -o "$FILE_NAME"
+        unzip -o "$FILE_NAME"
+        find . -type f -not \( -name sver -or -name sver.exe \) -delete
+
+    - name: add path
+      shell: bash
+      run: echo "${{ runner.tool_cache }}/sver" >> "$GITHUB_PATH"


### PR DESCRIPTION
I propose to improve the `setup` action, to cache the executable for network traffic reduction (potentially avoiding the rate limit due to lack of authentication). I also fixed the workflow directory to make it work on self-hosted runner, where we're rejected with permission denied error on moving the executable into `/usr/local/bin/` (with no `sudo` privilege). Tested on my fork [here](https://github.com/itchyny/sver-actions/actions), and also on my private repository on self-hosted runner (confirmed that `${{ runner.tool_cache }}` directory is writable without sudo).