### PR TITLE
Detect runner OS and architecture automatically in the setup action

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -6,20 +6,18 @@ jobs:
   latest:
     strategy:
       matrix:
-        job:
-          - os: linux
-            runs-on: ubuntu-latest
-          - os: macos
-            runs-on: macos-latest
-          - os: windows
-            runs-on: windows-latest
+        runs-on:
+          - ubuntu-latest
+          - ubuntu-slim
+          - ubuntu-26.04-arm
+          - macos-latest
+          - macos-26-intel
+          - windows-latest
       fail-fast: false
-    runs-on: ${{ matrix.job.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./setup
-        with:
-          os: ${{ matrix.job.os }}
       - name: sver calc
         shell: bash
         run: sver calc

--- a/setup/README.md
+++ b/setup/README.md
@@ -10,23 +10,29 @@ Install sver and set the path just by adding the following line to steps.
 - uses: mitoma/sver-actions/setup@v1
 ```
 
+If you do not set `os` and `arch`, the action uses the operating system and
+CPU architecture of the runner it runs on, so it works on Linux, macOS and
+Windows runners, including ARM64, without any options.
+
 With all options set:
 
 ```yaml
 - uses: mitoma/sver-actions/setup@v1
   with:
     os: linux
+    arch: amd64
     version: v0.1.14
     sha256sum: 407875b9e2263fb3ca94a6be166cd280f92404f01b1a00989a6deec441635706
 ```
 
 ### option
 
-| name      | value                                    |
-| --------- | ---------------------------------------- |
-| os        | `linux` or `macos` or `windows`          |
-| version   | released sver version. [sver releases][] |
-| sha256sum | sha256sum of artifact zip file           |
+| name      | value                                                                       |
+| --------- | --------------------------------------------------------------------------- |
+| os        | `linux` or `macos` or `windows` (defaults to the runner's operating system) |
+| arch      | `amd64` or `arm64` (defaults to the runner's CPU architecture)              |
+| version   | released sver version. [sver releases][]                                    |
+| sha256sum | SHA-256 hash of the artifact zip file                                       |
 
 Please refer to the `SHASUMS256.txt` included in the [sver releases][] for the sha256 hash.
 

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -5,11 +5,15 @@ inputs:
   version:
     description: 'sver release version'
     required: false
-    default: 'v0.1.20'
+    default: 'v0.1.21'
   os:
     description: 'sver release os'
     required: false
-    default: 'linux'
+    default: ''
+  arch:
+    description: 'sver release arch'
+    required: false
+    default: ''
   sha256sum:
     description: 'sver sha256sum'
     required: false
@@ -23,26 +27,37 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ runner.tool_cache }}/sver
-        key: sver-${{ runner.os }}-${{ runner.environment }}-${{ inputs.version }}-${{ inputs.os }}-amd64
+        key: sver-${{ inputs.os || runner.os }}-${{ inputs.arch || runner.arch }}-${{ runner.environment }}-${{ inputs.version }}
 
     - name: install sver
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        OS: ${{ inputs.os }}
+        ARCH: ${{ inputs.arch }}
+        SHA256SUM: ${{ inputs.sha256sum }}
       run: |
-        FILE_NAME="sver_${{ inputs.version }}_${{ inputs.os }}_amd64.zip"
-        FILE_URL="https://github.com/mitoma/sver/releases/download/${{ inputs.version }}/$FILE_NAME"
-        mkdir -p "${{ runner.tool_cache }}/sver"
-        cd "${{ runner.tool_cache }}/sver"
-        curl -f -L "$FILE_URL" -o "$FILE_NAME"
+        OS=$(tr '[:upper:]' '[:lower:]' <<< "${OS:-$RUNNER_OS}")
+        ARCH=$(tr '[:upper:]' '[:lower:]' <<< "${ARCH:-$RUNNER_ARCH}")
+        [[ "$ARCH" == "x64" ]] && ARCH=amd64
+        echo "Installing sver ${VERSION} (${OS}/${ARCH})"
+        FILE_NAME="sver_${VERSION}_${OS}_${ARCH}.zip"
+        DOWNLOAD_URL="https://github.com/mitoma/sver/releases/download/${VERSION}/$FILE_NAME"
+        echo "::debug::Download URL: $DOWNLOAD_URL"
+        mkdir -p "$RUNNER_TOOL_CACHE/sver"
+        cd "$RUNNER_TOOL_CACHE/sver"
+        curl -sSfL "$DOWNLOAD_URL" -o "$FILE_NAME"
         command -v sha256sum >/dev/null || sha256sum() { shasum -a 256 "$@"; }
         FILE_SHA256SUM=$(sha256sum "$FILE_NAME" | cut -f1 -d" ")
-        if [[ -n "${{ inputs.sha256sum }}" && "$FILE_SHA256SUM" != "${{ inputs.sha256sum }}" ]]; then
-          echo "invalid binary. expect: ${{ inputs.sha256sum }} actual: ${FILE_SHA256SUM}"
+        echo "::debug::SHA-256 checksum: $FILE_SHA256SUM"
+        if [[ -n "$SHA256SUM" && "$FILE_SHA256SUM" != "$SHA256SUM" ]]; then
+          echo "::error::invalid binary. expect: $SHA256SUM actual: $FILE_SHA256SUM"
           exit 1
         fi
-        unzip -o "$FILE_NAME"
+        unzip -qo "$FILE_NAME"
         find . -type f -not \( -name sver -or -name sver.exe \) -delete
 
     - name: add path
       shell: bash
-      run: echo "${{ runner.tool_cache }}/sver" >> "$GITHUB_PATH"
+      run: echo "$RUNNER_TOOL_CACHE/sver" >> "$GITHUB_PATH"


### PR DESCRIPTION
The setup action previously required `os` input to be set explicitly (defaulting to `linux`) and hard-coded `amd64`, so it couldn't install `sver` on ARM runners and needed manual configuration per platform.

This PR makes `os` and `arch` default to the runner's own OS and CPU architecture, so we can use this action on any platform without needing to specify them manually (enabling setting up `sver` in matrix jobs on multiple platforms).
